### PR TITLE
Add proper include for macOS

### DIFF
--- a/src/cobra_heap.c
+++ b/src/cobra_heap.c
@@ -64,7 +64,7 @@ extern void lock_print(int);
 extern void unlock_print(int);
 
 #ifdef __APPLE__
-	#include <malloc.h>
+	#include <stdlib.h>
 	#define sbrk	malloc
 #else
 	extern void *sbrk(int);


### PR DESCRIPTION
```
cobra_heap.c:67:11: fatal error: 'malloc.h' file not found
```