### PR TITLE
Fix a few cwe messages to use a consistent output format

### DIFF
--- a/src_app/cwe_120.c
+++ b/src_app/cwe_120.c
@@ -152,10 +152,10 @@ cwe120_check_gen(const int which, const char *v, const char *w)
 		{	printf("cwe_120_1: %d warnings: %s performs no bounds checking, (use %s)\n", w_cnt, v, w);
 		} else
 		{	char *buf;
-			int len = strlen(v)+strlen(w)+strlen("cwe_120_1,  performs no bounds checking, (use )");
+			int len = strlen(v)+strlen(w)+strlen("cwe_120_1:  performs no bounds checking, (use )");
 
 			buf = (char *) emalloc( (len+1)*sizeof(char) );
-			sprintf(buf, "cwe_120_1, %s performs no bounds checking, (use %s)", v, w);
+			sprintf(buf, "cwe_120_1: %s performs no bounds checking, (use %s)", v, w);
 
 			for (i = 0; i < Ncore; i++)
 			{	switch (which) {
@@ -371,7 +371,7 @@ report_120_2(void)
 	{	w_cnt += size_fct(thr[i].Snprintf);
 	}
 	if (w_cnt > 0)
-	{	buf = "cwe_120_2, snprintf  :: missing width limit on %%s";
+	{	buf = "cwe_120_2: snprintf  :: missing width limit on %%s";
 
 		if (no_display)
 		{	printf("cwe_120_2: %d warnings: %s\n", w_cnt, buf);
@@ -384,7 +384,7 @@ report_120_2(void)
 	{	w_cnt += size_fct(thr[i].Scanf);
 	}
 	if (w_cnt > 0)
-	{	buf = "cwe_120_2, scanf  :: missing width limit on %%s";
+	{	buf = "cwe_120_2: scanf  :: missing width limit on %%s";
 
 		if (no_display)
 		{	printf("cwe_120_2: %d warnings: %s\n", w_cnt, buf);

--- a/src_app/cwe_131.c
+++ b/src_app/cwe_131.c
@@ -210,7 +210,7 @@ cwe131_report(void)
 
 		for (mycur = prim; mycur; mycur = mycur->nxt)
 		{	if (mycur->mark == 131)
-			{	printf("%s:%d: cwe_131, missing sizeof() in memory allocation?\n",
+			{	printf("%s:%d: cwe_131: missing sizeof() in memory allocation?\n",
 					mycur->fnm, mycur->lnr);
 				mycur->mark = 0;
 			} else if (mycur->mark == 1310)
@@ -218,11 +218,11 @@ cwe131_report(void)
 				Prim *b = mycur->bound;
 				Prim *nmm = mycur->jmp;
 
-				printf("%s:%d:  cwe_131, out of bound array indexing error on %s?\n",
+				printf("%s:%d:  cwe_131: out of bound array indexing error on %s?\n",
 					q->fnm, q->lnr, nmm?nmm->txt:"-");
 				if (b
 				&&  strcmp(b->txt, "malloc") != 0)
-				{	printf("%s:%d:  cwe_131, array %s was allocated at %s:%d\n",
+				{	printf("%s:%d:  cwe_131: array %s was allocated at %s:%d\n",
 						q->fnm, q->lnr, b->txt, b->fnm, b->lnr);
 				}
 				mycur->mark  = 0;

--- a/src_app/cwe_416.c
+++ b/src_app/cwe_416.c
@@ -313,7 +313,7 @@ cwe416_report(void)
 		{	if (no_display)
 			{	w_cnt++;
 			} else if (mycur->bound)
-			{	printf("%s:%d: cwe_416, use after free of %s?\n",
+			{	printf("%s:%d: cwe_416: use after free of %s?\n",
 					mycur->fnm, mycur->lnr, mycur->bound->txt);
 				mycur->bound = 0;
 			}

--- a/src_app/cwe_457.c
+++ b/src_app/cwe_457.c
@@ -424,7 +424,7 @@ report_457(void)
 	while (cobra_nxt())
 	{	if (cur->mset[2] == 457)
 		{	if (!no_display)
-			{	printf("%s:%d: cwe_457, uninitialized var %s?\n",
+			{	printf("%s:%d: cwe_457: uninitialized var %s?\n",
 					cur->fnm, cur->lnr, cur->txt);
 			}
 			cur->mset[2] = 0;

--- a/src_app/cwe_468.c
+++ b/src_app/cwe_468.c
@@ -61,7 +61,7 @@ cwe468_report(void)
 			if (no_display)
 			{	w_cnt++;
 			} else
-			{	printf("%s:%d: cwe_468, risky cast using pointer arithmetic\n",
+			{	printf("%s:%d: cwe_468: risky cast using pointer arithmetic\n",
 					mycur->fnm, mycur->lnr);
 	}	}	}
 

--- a/src_app/cwe_805.c
+++ b/src_app/cwe_805.c
@@ -185,13 +185,13 @@ cwe805_report(void)
 
 	for (mycur = prim; mycur; mycur = mycur->nxt)
 	{	if (mycur->mark == 805)
-		{	printf("%s:%d: cwe_805, suspicious sizeof in strncpy, ",
+		{	printf("%s:%d: cwe_805: suspicious sizeof in strncpy, ",
 				mycur->fnm, mycur->lnr);
 			printf("strncat, or memcpy for other var than %s\n",
 				mycur->txt);
 			mycur->mark = 0;
 		} else if (mycur->mark == 8050)
-		{	printf("%s:%d: cwe_805, fct '%s' may ",
+		{	printf("%s:%d: cwe_805: fct '%s' may ",
 				mycur->fnm, mycur->lnr, mycur->txt);
 			printf("return a zero or negative value\n");
 			mycur->mark = 0;
@@ -215,12 +215,12 @@ cwe805_0(void)
 		}
 
 		if (cnt1 > 0)
-		{	printf("cwe_805, %d warnings: suspicious ", cnt1);
+		{	printf("cwe_805: %d warnings: suspicious ", cnt1);
 			printf("sizeof in strncpy, strncat, or memcpy\n");
 		}
 
 		if (cnt2 > 0)
-		{	printf("cwe_805, %d warnings: fct may return zero ", cnt2);
+		{	printf("cwe_805: %d warnings: fct may return zero ", cnt2);
 			printf("or negative value (used in array index)\n");
 		}
 	} else


### PR DESCRIPTION
Some messages were using ',' after the cwe issue identifier rather than ":"

Consistently using a colon for the field separate allows for easier automatic parsing of the issue output. 

Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>