### PR TITLE
Compares type names of encountered extern and original declarations

### DIFF
--- a/rules/main/extern.cobra
+++ b/rules/main/extern.cobra
@@ -28,13 +28,13 @@
 		{	Next;
 		}
 		r = Extern[q.txt];
-		if (r.lnr == 0 || r.type == .type)
+		if (r.lnr == 0 || r.txt == .txt)
 		{	Next;
 		}
 		cnt++;
 		if (!terse)
-		{	print " " cnt ": " .fnm ":" .lnr ": " q.txt " declared as " .type;
-			print " but as extern " r.type " at " r.fnm ":" r.lnr "\n";
+		{	print " " cnt ": " .fnm ":" .lnr ": " q.txt " declared as " .txt;
+			print " but as extern " r.txt " at " r.fnm ":" r.lnr "\n";
 	}	}
 %}
 %{


### PR DESCRIPTION
In the given code, the types of the two tokens are being compared. Since the current token . and the token r are both data types
r.type = type
.type = type
and hence r.type == .type is always true

Hence their .txt should be compared instead