### PR TITLE
Avoid truncating the error message text

### DIFF
--- a/src_app/json_convert.c
+++ b/src_app/json_convert.c
@@ -246,7 +246,7 @@ again:
 			}
 			if (*q == '"')
 			{	char *r = q+1;
-				while (*r != '\0' && *r != '"' && !isspace((int) *r))
+				while (*r != '\0' && *r != '"')
 				{	r++;
 				}
 				*r = '\0';


### PR DESCRIPTION
Currently, when using the json_convert utility to convert from JSON to other output formats, the rule message text is getting truncated at the first space. 

For example, the JSON entry like this:

```json
[
  { "type"  :   "(Required)  #include directives in a file shall only be preceded by other pre-processor directives or comments.",
    "message"   :   "lines 17..29",
    "file"  :   "time.c",
    "line"  :   17,
    "cobra" :   "1 1 40"
  }
]
```
Is getting converted to this SARIF output:

```json
        "rules": [
            {
              "id": "R0",
              "fullDescription": {
                "text": "(Required)"
              },
              "messageStrings": {
                "default": {
                  "text": "lines 69..69"
                }
              }
            },
```
Where the string "(Required)  #include directives in a file shall only be preceded by other pre-processor directives or comments." is getting truncated to "(Required)" in the output.


Signed-off-by: Michael Jeronimo <michael.jeronimo@openrobotics.org>