### PR TITLE
Update cobra_lib.c

### DIFF
--- a/src/cobra_lib.c
+++ b/src/cobra_lib.c
@@ -2772,7 +2772,7 @@ extend_range(void *arg)
 		{	break;
 		}
 		if (r_apply(r, r, s, 0))
-		{	if (*t && !r_apply(r, r->nxt, t, 1))
+		{	if (*t && !r_apply(q, r->nxt, t, 1))
 			{	continue;
 			}
 			local_cnt++;


### PR DESCRIPTION
Made the second apply reference the original marked range in order to support using $$ in the second argument of an extend.