### PR TITLE
Fixed compilation errors on latest GCC (13.2)

### DIFF
--- a/src/cobra_lib.c
+++ b/src/cobra_lib.c
@@ -1453,7 +1453,8 @@ load_map(char *s)
 	int h;
 
 	if ((fd = fopen(s, "r")) == NULL)
-	{	if (strlen(s) + strlen(C_BASE) + 2 < sizeof(a))
+	{	int formatted_file_name = strlen(s) + strlen(C_BASE) + 2;
+		if (formatted_file_name < sizeof(a))
 		{	snprintf(a, sizeof(a), "%s/%s", C_BASE, s);
 			fd = fopen(a, "r");
 		} else


### PR DESCRIPTION
On the latest GCC, Cobra fails to compile on the following code, because it thinks that the string output by `snprintf` can be larger than the buffer `a`, and truncated, even though logically, the bounds check prevents this.

```c
if (strlen(s) + strlen(C_BASE) + 2 < sizeof(a)) {
  snprintf(a, sizeof(a), "%s/%s", C_BASE, s);
  fd = fopen(a, "r");
} else {
  fprintf(stderr, "error: name too long '%s/%s'\n", C_BASE, s);
}
```

The error thrown by GCC:
```
cobra_lib.c: In function ‘load_map’:
cobra_lib.c:1457:52: error: ‘%s’ directive output may be truncated writing up to 1021 bytes into a region of size between 2 and 1023 [-Werror=format-truncation=]
 1457 |                 {       snprintf(a, sizeof(a), "%s/%s", C_BASE, s);
      |                                                    ^~
cobra_lib.c:1457:25: note: ‘snprintf’ output between 2 and 2044 bytes into a destination of size 1024
 1457 |                 {       snprintf(a, sizeof(a), "%s/%s", C_BASE, s);
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [<builtin>: cobra_lib.o] Error 1
```

System:
* x86 linux 6.6.9-arch1-1
* gcc (GCC) 13.2.1 20230801