### PR TITLE
fix: Added checks to  functions in order to fix a build error

### DIFF
--- a/src/cobra_json.c
+++ b/src/cobra_json.c
@@ -1,3 +1,4 @@
+// clang-format off
 /*
  * This file is part of the public release of Cobra. It is subject to the
  * terms in the License file that is included in this source directory.
@@ -65,7 +66,11 @@ check_bvar(Prim *c)
 	if (c->mark & 4)	// matched
 	{	sprintf(buf, "->%d", c->lnr);
 	} else 			// defined
-	{	snprintf(buf, sizeof(buf), "%s %d", c->txt, c->lnr);
+	{	
+		if (snprintf(buf, sizeof(buf), "%s %d", c->txt, c->lnr) >= sizeof(buf)) {
+			printf("error: formatting variable too long, max: %d\n", (int) sizeof(buf));
+			return;
+		}
 	}
 	if (strstr(bvars, buf))
 	{	return;

--- a/src/cobra_lex.c
+++ b/src/cobra_lex.c
@@ -1,3 +1,4 @@
+// clang-format off
 /*
  * This file is part of the public release of Cobra. It is subject to the
  * terms in the License file that is included in this source directory.
@@ -341,7 +342,10 @@ static void
 show1(char *type, int cid)		// item (stands for itself)
 {
 	assert(cid >= 0 && cid < Ncore);
-	snprintf(Px.lex_out, sizeof(Px.lex_out), "%s", type);
+	if (snprintf(Px.lex_out, sizeof(Px.lex_out), "%s", type) >= sizeof(Px.lex_out)) {
+		printf("error: name of type was longer than the lexer's output");
+		return;
+	}
 	process_line(Px.lex_out, cid);
 }
 
@@ -349,8 +353,11 @@ static void
 show2(const char *type, const char *raw, int cid)	// item, count, raw text
 {
 	assert(cid >= 0 && cid < Ncore);
-	snprintf(Px.lex_out, sizeof(Px.lex_out), "%s\t%d\t%s",
-		type, (int) strlen(raw), raw);
+	if (snprintf(Px.lex_out, sizeof(Px.lex_out), "%s\t%d\t%s",
+		type, (int) strlen(raw), raw) >= sizeof(Px.lex_out)) {
+		printf("error: name of type was longer than the lexer's output");
+		return;
+	};
 	process_line(Px.lex_out, cid);
 }
 
@@ -683,7 +690,11 @@ name(int c, int cid)
 	{	int a = isdirective(cid);
 		if (a)
 		{	char buf[MAXYYTEXT+64];
-			snprintf(buf, sizeof(buf), "#%s", Px.lex_yytext);
+			if (snprintf(buf, sizeof(buf), "#%s", Px.lex_yytext) >= sizeof(buf)) {
+				printf("error: the directives \"%s\" were too long, max: %d\n", 
+					 Px.lex_yytext, (int) sizeof(buf));
+				return;
+			}
 			show2("cpp", buf, cid);
 			Px.lex_preprocessing = 2; // need EOP token
 			switch (a) {
@@ -962,8 +973,12 @@ void
 line(int cid)	// called also in cobra_prep.c
 {
 	assert(cid >= 0 && cid < Ncore);
-	snprintf(Px.lex_out, sizeof(Px.lex_out), "line\t%d\t%s",
-		Px.lex_lineno, Px.lex_fname);
+	if (snprintf(Px.lex_out, sizeof(Px.lex_out), "line\t%d\t%s",
+		Px.lex_lineno, Px.lex_fname) >= sizeof(Px.lex_out)) {
+		printf("error: line format directive was too long, max: %d\n",
+				 (int) sizeof(Px.lex_out));
+		return;
+	}
 	process_line(Px.lex_out, cid);	// where the data structure is build
 }
 
@@ -1142,7 +1157,12 @@ c_lex(int cid)	// called in cobra_prep.c
 			if (Px.lex_preprocessing == 1)
 			{	char buf[NOUT+64];
 				char_or_str(n, cid);
-				snprintf(buf, sizeof(buf), "# %d %s", Px.lex_lineno, Px.lex_yytext);
+				if (snprintf(buf, sizeof(buf), "# %d %s", Px.lex_lineno, Px.lex_yytext) 
+						>= sizeof(buf)) {
+						printf("error: preprocessing format is too long, max: %d\n",
+						 (int) sizeof(buf));
+						return 1;
+				}
 				memset(Px.lex_cpp, 0, sizeof(Px.lex_cpp));
 				if (no_cpp)
 				{	do {

--- a/src/cobra_lib.c
+++ b/src/cobra_lib.c
@@ -1,3 +1,4 @@
+// clang-format off
 /*
  * This file is part of the public release of Cobra. It is subject to the
  * terms in the License file that is included in this source directory.
@@ -283,9 +284,13 @@ reproduce(const int seq, const char *s)
 				snprintf(tag, sizeof(tag), " ");
 			} else
 			{	if (scrub)
-				{	snprintf(src, sizeof(src), "%s:%d: %.2s  ",
+				{	
+					if (snprintf(src, sizeof(src), "%s:%d: %.2s  ",
 					  cobra_fnm(), cobra_lnr(),
-					  (q->lnr == cur->lnr && n > 1)?"> ":"  ");
+					  (q->lnr == cur->lnr && n > 1)?"> ":"  ") >= sizeof(src)) {
+						fprintf(stderr, "error: cannot print tag, function name too long\n");
+						return;
+					}
 					memset(tag, ' ', strlen(src));
 					tag[strlen(src)] = '\0';
 				} else

--- a/src/cobra_prep.c
+++ b/src/cobra_prep.c
@@ -1,3 +1,4 @@
+// clang-format off
 /*
  * This file is part of the public release of Cobra. It is subject to the
  * terms in the License file that is included in this source directory.
@@ -1081,8 +1082,12 @@ add_file(char *f, int cid, int slno)
 			    + 8;	// some margin
 
 		buf = (char *) hmalloc(n, cid, 124);
-		snprintf(buf, n, "%s %s -w -E -x %s %s > %s",
-			    CPP, Preproc[cid], lang, f, fnm);
+		if (snprintf(buf, n, "%s %s -w -E -x %s %s > %s",
+			    CPP, Preproc[cid], lang, f, fnm) >= n) {
+			fprintf(stderr, "argument list is too long\n");
+			unlink(fnm);
+			return 0;
+		}
 
 		if (verbose == 1)
 		{	printf("%s\n", buf);

--- a/src/cobra_prim.c
+++ b/src/cobra_prim.c
@@ -1,3 +1,4 @@
+// clang-format off
 /*
  * This file is part of the public release of Cobra. It is subject to the
  * terms in the License file that is included in this source directory.
@@ -145,15 +146,11 @@ dogrep(const char *s)
 
 	for (n = 0; n < NHASH; n++)
 	for (f = files[n]; f; f = f->nxt)
-	{	if (strlen(s)
-		+   strlen(f->s)
-		+   strlen("grep -n -e -q \"\"")
-		+   1 >= sizeof(cmd))
-		{	printf("search pattern too long\n");
-			return;
+	{ if (snprintf(cmd, sizeof(cmd), "grep -q -n -e  \"%s\" %s",
+			s, f->s) >= sizeof(cmd)) {
+				printf("search pattern too long\n");
+				return;
 		}
-		snprintf(cmd, sizeof(cmd), "grep -q -n -e  \"%s\" %s",
-			s, f->s);
 		if (system(cmd) == 0)	// dogrep
 		{	printf("%s:\n", f->s);
 		}


### PR DESCRIPTION
This PR is a rewrite of my previous PR #75, which addresses more of the uses of `snprintf` instead, of just one call site

When I was reading through the calls to `snprintf`, I found that most of them actually should never trigger the compiler warning, due to using constant-sized formats, or the strings being printed are of constant size themselves, which the compiler should be able to check.

The calls that I replaced are the ones that I deemed most problematic, and where applicable, used similar error handling to other errors.

I would appreciate any comments if the style is off, or you think I missed any special cases!

I can also confirm that this fixes the compile errors for me on my machine